### PR TITLE
Added functionality to get properties returned

### DIFF
--- a/library/commvault.py
+++ b/library/commvault.py
@@ -335,6 +335,9 @@ def main():
         else:
             result['output'] = output
 
+        if obj_name == 'client' and 'prop' in method:
+            result['ansible_facts'] = client.properties
+
     module.exit_json(**result)
 
 


### PR DESCRIPTION
There was no way of getting the properties back on client when you used for example `_get_client_properties` in the `Client.py` class, as it only updates the instantiated class. Added a way of returning properties if the method name was something with "property" and only in the client operation. 

Update my code if you want to add it for other functions as well. 